### PR TITLE
[UPDATE] 페이지 로그인 유저 관련 업뎃, main 페이지에 시작일 및 종료일 출력, 참가자 수 구하기 (미완)

### DIFF
--- a/DaDoc/src/main/java/com/team1/dadoc/challenge/controller/ChallengeController.java
+++ b/DaDoc/src/main/java/com/team1/dadoc/challenge/controller/ChallengeController.java
@@ -35,13 +35,13 @@ public class ChallengeController {
 	}
 	
 	// 챌린지 업로드 & DB 저장
-	@RequestMapping(value="/challenge/register_form")
+	@RequestMapping(value="/challenge/private/register_form")
 	public ModelAndView registerForm(HttpServletRequest request) {
-		return new ModelAndView("challenge/register_form");
+		return new ModelAndView("challenge/private/register_form");
 	}
 	
 	// 챌린지 DB에 집어넣기 
-	@RequestMapping(value="/challenge/register")
+	@RequestMapping(value="/challenge/private/register")
 	public ModelAndView register(ChallengesDto dto, ModelAndView mView, HttpServletRequest request) {		
 		// form에서 dto로 데이터 받아오고
 		// dto: challenge 정보와 MultipartFile image 정보를 가지고 있다.
@@ -56,11 +56,11 @@ public class ChallengeController {
 	// 챌린지 상세보기 (detail 페이지)
 	// 게시글의 num이 parameter get 방식으로 넘어온다.
 	@RequestMapping(value="/challenge/detail", method= RequestMethod.GET)
-	public ModelAndView detail(ModelAndView mView, @RequestParam int num, @RequestParam String title) {
+	public ModelAndView detail(HttpServletRequest request, ModelAndView mView, @RequestParam int num, @RequestParam String title) {
 		//detail 페이지에 필요한 data를 num을 통해 가져와서 ModelAndView에 저장
 		
 		service.getDetail(mView,num);
-		String id = "hungry";
+		String id = request.getSession().getId();
 		PhotoShotDto dto = new PhotoShotDto();
 		dto.setId(id);
 		dto.setChallengeTitle(title);

--- a/DaDoc/src/main/java/com/team1/dadoc/challenge/service/ChallengeServiceImpl.java
+++ b/DaDoc/src/main/java/com/team1/dadoc/challenge/service/ChallengeServiceImpl.java
@@ -107,12 +107,11 @@ public class ChallengeServiceImpl implements ChallengeService {
 		}
 		//ChallengesDto 객체를 이용해서 회원 목록을 얻어온다.
 		List<ChallengesDto> list = challengesDao.getList(dto);
-			   
+				
 		//하단 시작 페이지 번호 
 		int startPageNum = 1 + ((pageNum-1)/PAGE_DISPLAY_COUNT) * PAGE_DISPLAY_COUNT;
 		//하단 끝 페이지 번호
 		int endPageNum = startPageNum + PAGE_DISPLAY_COUNT - 1;
-			   
 		//전체 row 의 갯수
 		int totalRow = challengesDao.getCount();
 		//전체 페이지의 갯수 구하기

--- a/DaDoc/src/main/java/com/team1/dadoc/challenger/dao/ChallengerDao.java
+++ b/DaDoc/src/main/java/com/team1/dadoc/challenger/dao/ChallengerDao.java
@@ -1,8 +1,12 @@
 package com.team1.dadoc.challenger.dao;
 
+import java.util.List;
+
 import com.team1.dadoc.challenger.dto.ChallengerDto;
 
 public interface ChallengerDao {
 	//챌린지 참가 신청
 	public void insert(ChallengerDto dto);
+	//챌린지 별 참가자 수 구하기
+	public int getChallengers(String title);
 }

--- a/DaDoc/src/main/java/com/team1/dadoc/challenger/dao/ChallengerDaoImpl.java
+++ b/DaDoc/src/main/java/com/team1/dadoc/challenger/dao/ChallengerDaoImpl.java
@@ -1,5 +1,7 @@
 package com.team1.dadoc.challenger.dao;
 
+import java.util.List;
+
 import org.apache.ibatis.session.SqlSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
@@ -16,5 +18,12 @@ public class ChallengerDaoImpl implements ChallengerDao{
 	public void insert(ChallengerDto dto) {
 		session.insert("challenger.insert", dto);
 	}
+
+	@Override
+	public int getChallengers(String title) {
+		return session.selectOne("challenger.getChallenger"); 
+	}
+
+
 
 }

--- a/DaDoc/src/main/java/com/team1/dadoc/challenger/dto/ChallengerDto.java
+++ b/DaDoc/src/main/java/com/team1/dadoc/challenger/dto/ChallengerDto.java
@@ -8,10 +8,14 @@ public class ChallengerDto {
 	private int period;
 	private int stamp;
 	private String success;
+	private int countNum;
 	
 	public ChallengerDto() {}
 	
-	public ChallengerDto(int num, String id, String challengeTitle, int period, int stamp, String success) {
+
+
+	public ChallengerDto(int num, String id, String challengeTitle, int period, int stamp, String success,
+			int countNum) {
 		super();
 		this.num = num;
 		this.id = id;
@@ -19,7 +23,10 @@ public class ChallengerDto {
 		this.period = period;
 		this.stamp = stamp;
 		this.success = success;
+		this.countNum = countNum;
 	}
+
+
 
 	public int getNum() {
 		return num;
@@ -68,6 +75,15 @@ public class ChallengerDto {
 	public void setSuccess(String success) {
 		this.success = success;
 	}
+
+	public int getCountNum() {
+		return countNum;
+	}
+
+	public void setCountNum(int countNum) {
+		this.countNum = countNum;
+	}
+	
 	
 	
 }

--- a/DaDoc/src/main/java/com/team1/dadoc/filter/LoginFilter.java
+++ b/DaDoc/src/main/java/com/team1/dadoc/filter/LoginFilter.java
@@ -17,7 +17,7 @@ import javax.servlet.http.HttpSession;
 // /users/private/* 하위에서 일어나는 모든 요청에 filtering
 // /cafe/private/* 
 // 여러 장소에 filtering 하게 되었다! -> urlPatterns = {필터링 경로, ... } 로 여러 url 패턴을 넣을 수 있다!
-@WebFilter(urlPatterns = { "/users/private/*" })
+@WebFilter(urlPatterns = { "/users/private/*" , "/challenge/private/*"})
 public class LoginFilter implements Filter{
 
 	@Override

--- a/DaDoc/src/main/java/com/team1/dadoc/mybatis/ChallengerMapper.xml
+++ b/DaDoc/src/main/java/com/team1/dadoc/mybatis/ChallengerMapper.xml
@@ -6,4 +6,12 @@
 		(num, id, challengeTitle, period, stamp, success)
 		VALUES(challenger_seq.NEXTVAL, #{id}, #{challengeTitle}, #{period}, 0, 'false')
 	</insert>
+	
+	<select id="getChallenger" parameterType="int">
+			SELECT countnum
+				(SELECT challengeTitle, count(1) as countnum
+				FROM dadoc_challenger
+				GROUP BY challengeTitle)
+			WHERE challengeTitle = #{title}
+	</select>
 </mapper>

--- a/DaDoc/src/main/webapp/WEB-INF/views/challenge/detail.jsp
+++ b/DaDoc/src/main/webapp/WEB-INF/views/challenge/detail.jsp
@@ -128,13 +128,11 @@
 					<form
 						action="${pageContext.request.contextPath}/challenge/photoShot_upload.do"
 						method="post" id="photoShotForm" enctype="multipart/form-data">
-						<input type="file" name="image" id="image"
-							accept=".jpg, .jpeg, .png, .JPG, .JPEG, .gif" /> <input
-							type="hidden" name="id" id="id" value="hungry" /> <input
-							type="hidden" name="challengeTitle" id="challengeTitle"
-							value="${dto.title}" /> <input type="hidden" name="num" id="num"
-							value="${dto.num }" /> <input type="hidden" name="period"
-							id="period" value="${dto.period }" />
+						<input type="file" name="image" id="image" accept=".jpg, .jpeg, .png, .JPG, .JPEG, .gif" />
+						<input type="hidden" name="id" id="id" value="${sessionScope.id }" />
+						<input type="hidden" name="challengeTitle" id="challengeTitle" value="${dto.title}" /> 
+						<input type="hidden" name="num" id="num" value="${dto.num }" /> 
+						<input type="hidden" name="period" id="period" value="${dto.period }" />
 
 						<div class="modal-footer">
 							<button type="button" class="btn btn-secondary"
@@ -188,10 +186,9 @@
 					<form
 						action="${pageContext.request.contextPath}/challenge/insertChallenger.do"
 						method="post">
-						<input type="hidden" name="id" id="id" value="hungry" /> <input
-							type="hidden" name="challengeTitle" id="challengeTitle"
-							value="${dto.title}" /> <input type="hidden" name="period"
-							id="period" value="${dto.period}" />
+						<input type="hidden" name="id" id="id" value="${sessionScope.id }" />
+						 <input type="hidden" name="challengeTitle" id="challengeTitle" value="${dto.title}" /> 
+						 <input type="hidden" name="period" id="period" value="${dto.period}" />
 						<button type="submit" class="btn btn-primary">신청</button>
 					</form>
 				</div>

--- a/DaDoc/src/main/webapp/WEB-INF/views/challenge/main.jsp
+++ b/DaDoc/src/main/webapp/WEB-INF/views/challenge/main.jsp
@@ -120,6 +120,24 @@
 .pagination {
 	margin-bottom: 50px;
 }
+
+
+/*링크 들어간 글자 색 변경*/
+a{
+	color:#D0AF84;
+}
+
+/*마우스 올렸을 때 색 변경*/
+a:hover{
+	color:#966C3B;
+}
+
+/*챌린지 설명 부분 크기 고정*/
+#challenge-description{
+	width: 210px;
+	height: 130px;
+	margin-bottom: 20px;
+}
 </style>
 </head>
 <body>
@@ -148,10 +166,14 @@
 		</section>
 	<!-- 페이지 메인  -->
 	<div class="container py-4">
-
-		<button id="challengeBtn" type="button"
-			onclick="location.href='${pageContext.request.contextPath}/challenge/register_form.do'"
-			class="btn btn-rounded btn-tertiary mb-2">새로운 챌린지 개설하기</button>
+	<!-- 로그인 할 때만 새로운 챌린지를 개설할 수 있다. -->
+		<c:choose>
+			<c:when test="${not empty sessionScope.id}">
+				<button id="challengeBtn" type="button"
+				onclick="location.href='${pageContext.request.contextPath}/challenge/private/register_form.do'"
+				class="btn btn-rounded btn-tertiary mb-2">새로운 챌린지 개설하기</button>
+			</c:when>
+		</c:choose>
 		<div class="row">
 			<div class="col">
 				<div class="blog-posts">
@@ -171,21 +193,21 @@
 									<div class="post-content">
 										<h2
 											class="font-weight-semibold text-5 line-height-6 mt-3 mb-2 bold-family">
-											<a
-												href="${pageContext.request.contextPath}/challenge/detail.do?num=${tmp.num}&title=${tmp.title}">${tmp.title }</a>
+											<a href="${pageContext.request.contextPath}/challenge/detail.do?num=${tmp.num}&title=${tmp.title}">${tmp.title }</a>
 										</h2>
-										<p>${tmp.description}</p>
+										<p id="challenge-description">${tmp.description}</p>
 										<div class="post-meta">
-											<span><i class="far fa-user"></i> By <a href="#">${tmp.writer }</a>
-											</span> <span><i class="far fa-folder"></i> <a href="#">${tmp.type }</a>,
-												<a href="#">${tmp.category }</a> </span> <span><i
-												class="far fa-comments"></i> <a href="#">댓글 수 가져오기</a></span>
+											<span><i class="far fa-user"></i> By ${tmp.writer }</span> 
+											<span><i class="far fa-folder"></i> ${tmp.type },${tmp.category }</span> 
+											<span><i class="icon-calendar icons"> ${tmp.startDate } ~ ${tmp.endDate}</i></span>
+											<span><i class="icon-people icons"></i> <a href="#">참가자 수 가져오기</a></span>
 										</div>
 									</div>
+								</article>
 							</div>
 						</c:forEach>
 					</div>
-					</article>
+					
 				</div>
 			</div>
 

--- a/DaDoc/src/main/webapp/WEB-INF/views/challenge/private/register_form.jsp
+++ b/DaDoc/src/main/webapp/WEB-INF/views/challenge/private/register_form.jsp
@@ -16,7 +16,7 @@
 
 
 	<h1>챌린지 신청 폼입니다.</h1>
-	<form action="${pageContext.request.contextPath}/challenge/register.do" method="post" enctype="multipart/form-data" id="myForm" >
+	<form action="${pageContext.request.contextPath}/challenge/private/register.do" method="post" enctype="multipart/form-data" id="myForm" >
 		<!-- type radio -->
 		<p>-----타입 정하기-----</p>
 		<div>
@@ -29,7 +29,7 @@
 		</div>
 		<div>
 			<label class="control-label form-check-label" for="writer"></label>
-			<input class="control-label form-check-input" id="writer" name="writer" type="hidden" value="hungry" />
+			<input class="control-label form-check-input" id="writer" name="writer" type="hidden" value="${sessionScope.id }" />
 		</div>
 		<!-- title input -->
 		<p>-----챌린지 이름-----</p>


### PR DESCRIPTION
#75 

### 기능 구현

---

`<span><i class="icon-calendar icons"> ${tmp.startDate } ~ ${tmp.endDate}</i></span>`

main 페이지에 한 줄 추가했다.

### 추가 및 수정 페이지

---

- challenge 폴더에 private 폴더 추가해서 로그인 후에 접근 가능한 페이지를 옮김 (regiser_form.jsp)
- `@WebFilter(urlPatterns = { "/users/private/*" , "/challenge/private/*"})`  로그인 필터에 챌린지 private 폴더도 적용함
- detail, main, register_form에 writer parameter로 'writer'(임시)를 넣어놓은 것을 ${sessionScope.id}로 바꿔서 DB에 현재 접속한 id가 저장될 수 있게 함