### PR TITLE
[bug fix] 기본/상세 검색 상태 나누기

### DIFF
--- a/DaDoc/src/main/java/com/team1/dadoc/book/search/service/BookSearchServiceImpl.java
+++ b/DaDoc/src/main/java/com/team1/dadoc/book/search/service/BookSearchServiceImpl.java
@@ -60,7 +60,7 @@ public class BookSearchServiceImpl implements BookSearchService {
         	int i = 0;
         	while((inputLine = br.readLine()) != null) {
         		response.append(inputLine);
-        		System.out.println(inputLine);
+        		//System.out.println(inputLine);
         	}
         	//리더 닫기
         	br.close();

--- a/DaDoc/src/main/webapp/WEB-INF/views/booksearch/search_list.jsp
+++ b/DaDoc/src/main/webapp/WEB-INF/views/booksearch/search_list.jsp
@@ -223,12 +223,18 @@
 	            	endPageNum: 1,	//보여지는 끝 페이지 숫자
 	            	totalPageCount: 1	//페이지의 총 개수 : total, display 로 부터 만들어내기
 	            },
+	            isBasicSearch: false,	//기본 검색 상태
+	            isDetailSearch: false	//상세 검색 상태
 			},
 			methods: {
 				//네이버 상세검색 버튼을 눌러서 검색할 때 이벤트처리
 				submitDetailSearch(){
 					//검색버튼을 누른다 -> input 값 직접 변경(input hidden 은 v-model 이 통하지 X)
 					this.$refs.d_inputStart.value = 1;
+					
+					//상세 검색 상태로 만든다.
+					this.isBasicSearch = false;
+	            	this.isDetailSearch = true;
 					
 					//ajax 호출
 	            	this.detailSearch();
@@ -244,7 +250,7 @@
 					//여기서는 query, display, start 3가지가 들어온다.
 					const queryString = new URLSearchParams(new FormData(form)).toString();
 					
-					console.log('queryString : ' + queryString);
+					//console.log('queryString : ' + queryString);
 					
 					//vue 객체
 					const self = this;
@@ -256,7 +262,7 @@
 					})
 					.then(function(data){
 						//제발 json 으로 넘어와줘
-						console.log(data);
+						//console.log(data);
 						//우리는 data 의 items object 를 사용한다.
 						//data : 내부에 개개 책의 정보가 담긴 object 를 담고 있는 array 이다.
 						
@@ -287,15 +293,19 @@
 	                //현재 페이지를 수정하고
 	                this.paging_data.pageNum = pageNum;
 	               	
-	                //query 가 빈칸 -> detail 검색
-	                if(this.query == ''){
+	                //query 가 빈칸 -> detail 검색 -> 상세검색시에 query 가 빈칸이 아니면 오류가 생긴다.
+	                //-> 수정 : isBasicSearch, isDetailSearch 를 사용하여 상태를 관리한다.
+	                if(this.isDetailSearch){
+	                	alert('상세 검색');
+	                	//상세검색
 	                	// 화면 업데이트 -> form 의 start 를 바꾸고 -> 검색을 다시 한다.
 		                //-> input 값 직접 변경(input hidden 은 v-model 이 통하지 X)
 	                	this.$refs.d_inputStart.value = pageNum;
 	                	this.detailSearch();
-	                }else{//query 가 빈칸 X -> bastic 검색
+	                }else{//isBasicSearch 와 isDetailSearch 는 서로 반대의 값을 가짐 -> bastic 검색
 	                	// 화면 업데이트 -> form 의 start 를 바꾸고 -> 검색을 다시 한다.
 		                //-> input 값 직접 변경(input hidden 은 v-model 이 통하지 X)
+		                alert('기본 검색');
 		            	this.$refs.inputStart.value = pageNum;
 		                //ajax
 		            	this.basicSearch();
@@ -305,6 +315,10 @@
 	            submitBasicSearch(){
 	            	//검색버튼을 누른다 -> input 값 직접 변경(input hidden 은 v-model 이 통하지 X)
 	            	this.$refs.inputStart.value = 1;
+	            	
+	            	//기본 검색 상태로 만든다.
+	            	this.isBasicSearch = true;
+	            	this.isDetailSearch = false;
 	            	
 	            	//ajax 호출
 	            	this.basicSearch();
@@ -331,7 +345,7 @@
 					})
 					.then(function(data){
 						//제발 json 으로 넘어와줘
-						console.log(data);
+						//console.log(data);
 						//우리는 data 의 items object 를 사용한다.
 						//data : 내부에 개개 책의 정보가 담긴 object 를 담고 있는 array 이다.
 						self.searchList = data.items;
@@ -369,14 +383,14 @@
 					
 					
 					//임시 출력
-					console.log('searchList');
+/* 					console.log('searchList');
 					console.log(this.searchList);
 					console.log('list type : ' + typeof(this.searchList));
 					console.log('total : ' + this.total);
 					console.log('totalPageCount : ' + this.paging_data.totalPageCount);
 					console.log('pageNum : ' + this.paging_data.pageNum);
 					console.log('startPageNum : ' + this.paging_data.startPageNum);
-					console.log('endPageNum : ' + this.paging_data.endPageNum);
+					console.log('endPageNum : ' + this.paging_data.endPageNum); */
 				}
 			},
 			created(){


### PR DESCRIPTION
## 기능

1. 현재의 로직에서, 기본 검색인 query 검색 창에 무언가 입력되어 있으면, 페이지를 이동할 때 자동으로 기본검색이 되도록 짜여있다.
-> 이는 오류
2. bool 값을 이용해서, 해당 검색 버튼을 누를 때 movePage() method 에서 제대로 스위칭되어 ajax 요청할 수 있도록 수정
3. isBasicSearch / isDetailSearch 를 사용 (서로 반대의 true / false 값을 가짐)

## 상세 파일 & 설명

- search_list.jsp
    1. vue 의 data 영역에 isBasicSearch, isDetailSearch 추가

        ```jsx
        isBasicSearch: false,	//기본 검색 상태
        isDetailSearch: false	//상세 검색 상태
        ```

    2. submitDetailSearch() 메소드, submitBasicSearch() 메소드에 위의 두 값을 swiching 하는 코드 추가

        ```jsx
        //상세 검색 상태로 만든다.
        this.isBasicSearch = false;
        this.isDetailSearch = true;

        //기본 검색 상태로 만든다.
        this.isBasicSearch = true;
        this.isDetailSearch = false;
        ```

    3. movePage(pageNum) 메소드
        - 기존 로직

            query 가 빈칸 → detail 검색

        - 오류

            → 상세검색시에 query 가 빈칸이 아니면 오류가 생긴다.

        - 수정 : isBasicSearch, isDetailSearch 를 사용하여 상태를 관리한다.

            if 검색 조건을 

            `this.query == ''` →  `this.isDetailSearch` 으로 변경

    4. 자잘한 console.log 를 삭제